### PR TITLE
bump to zsh-bin 4.0.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ done
 build_dir=$CDIR/build
 
 rm -rf $build_dir
-mkdir -p $build_dir
+mkdir -p $build_dir/zsh-bin
 
 for f in entrypoint.sh zsh.sh
 do
@@ -27,7 +27,7 @@ distfile=zsh-5.8-linux-x86_64
 url="https://github.com/romkatv/zsh-bin/releases/download/v4.0.1/$distfile.tar.gz"
 tarname=`basename $url`
 
-cd $build_dir
+cd $build_dir/zsh-bin
 
 [ $QUIET ] && arg_q='-q' || arg_q=''
 [ $QUIET ] && arg_s='-s' || arg_s=''
@@ -42,5 +42,4 @@ else
 fi
 
 tar -xzf $tarname
-mv $distfile zsh-bin
 rm $tarname

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ done
 cp $CDIR/zshrc $build_dir/.zshrc
 
 distfile=zsh-5.8-linux-x86_64
-url="https://github.com/romkatv/zsh-bin/releases/download/v3.0.1/$distfile.tar.gz"
+url="https://github.com/romkatv/zsh-bin/releases/download/v4.0.1/$distfile.tar.gz"
 tarname=`basename $url`
 
 cd $build_dir


### PR DESCRIPTION
This PR bumps zsh-bin to v4.0.1. Notably it changed the directory structure in its release tarball.