### PR TITLE
Using latest zsh/bin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,8 +23,11 @@ do
 done
 cp $CDIR/zshrc $build_dir/.zshrc
 
+tag=v4.0.1
 distfile=zsh-5.8-linux-x86_64
-url="https://github.com/romkatv/zsh-bin/releases/download/v4.0.1/$distfile.tar.gz"
+tag=$(curl --silent https://api.github.com/repos/romkatv/zsh-bin/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+url="https://github.com/romkatv/zsh-bin/releases/download/$tag/$distfile.tar.gz"
+
 tarname=`basename $url`
 
 cd $build_dir/zsh-bin

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Support arguments (this recommend but not required):


### PR DESCRIPTION
build.sh
- Using the GitHub api to always get the newest version of zsh/bin

entrypoint.sh
- Execution is now possible on FreeBSD