### PR TITLE
Update wget progress parameter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ cd $build_dir/zsh-bin
 
 [ $QUIET ] && arg_q='-q' || arg_q=''
 [ $QUIET ] && arg_s='-s' || arg_s=''
-[ $QUIET ] && arg_progress='' || arg_progress='--show-progress'
+[ $QUIET ] && arg_progress='' || arg_progress='--progress bar'
 
 if [ -x "$(command -v wget)" ]; then
   wget $arg_q $arg_progress $url -O $tarname


### PR DESCRIPTION
## Problem
When installing, the `zsh` binary isn't retrieved when using `wget` as `--show-progress` was renamed to `--progress <progress-type>`.

## Resolution
I'm assuming the original behaviour was to show a progress bar, so I've corrected the parameter to use such.

## Logs
When failing to install `xxh-shell-zsh`:
```sh
> xxh +I xxh-shell-zsh
Install xxh-shell-zsh to local /home/cyrus/.xxh/.xxh/shells/xxh-shell-zsh
Git clone https://github.com/xxh/xxh-shell-zsh
Build xxh-shell-zsh
Unknown option 'show-progress'
tar (child): zsh-5.8-linux-x86_64.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
mv: cannot stat 'zsh-5.8-linux-x86_64/*': No such file or directory
rm: cannot remove 'zsh-5.8-linux-x86_64.tar.gz': No such file or directory
Installed /home/cyrus/.xxh/.xxh/shells/xxh-shell-zsh
```

When installing the patched version locally:
```sh
> xxh +I xxh-shell-zsh+path+$PWD
Install xxh-shell-zsh+path+/home/cyrus/Projects/forks/xxh-shell-zsh to local
/home/cyrus/.xxh/.xxh/shells/xxh-shell-zsh
Package source path: /home/cyrus/Projects/forks/xxh-shell-zsh
Build xxh-shell-zsh
zsh-5.8-linux-x86_64 100% [=========================================================>]    3.33M    --.-KB/s
                          [Files: 1  Bytes: 3.33M [4.51MB/s] Redirects: 1  Todo: 0  Errors: 0]
Installed /home/cyrus/.xxh/.xxh/shells/xxh-shell-zsh
```