### PR TITLE
Added ARM Architecture support for xxh-shell-zsh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,12 +28,12 @@ tag=v3.0.1
 arch=$(uname -m)
 if [[ $arch == x86_64* ]]; then
 	distfile=zsh-5.8-linux-x86_64
-elif  [[ $arch == arm* ]]; then
+elif [[ $arch == arm* ]]; then
 	distfile=zsh-5.8-linux-armv7l
 fi
 
-url="https://github.com/romkatv/zsh-bin/releases/download/$tag/$distfile.tar.gz"
 
+url="https://github.com/romkatv/zsh-bin/releases/download/$tag/$distfile.tar.gz"
 tarname=`basename $url`
 
 cd $build_dir/zsh-bin
@@ -51,5 +51,10 @@ else
 fi
 
 tar -xzf $tarname
-mv $tarname/* .
+if [[ $arch == x86_64* ]]; then
+mv zsh-5.8-linux-x86_64/* .
+elif  [[ $arch == arm* ]]; then
+mv zsh-5.8-linux-armv7l/* .
+fi
+
 rm $tarname

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,13 @@ cp $CDIR/zshrc $build_dir/.zshrc
 
 # tag=$(curl --silent https://api.github.com/repos/romkatv/zsh-bin/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
 tag=v3.0.1
-distfile=zsh-5.8-linux-x86_64
+arch=$(uname -m)
+if [[ $arch == x86_64* ]]; then
+	distfile=zsh-5.8-linux-x86_64
+elif  [[ $arch == arm* ]]; then
+	distfile=zsh-5.8-linux-armv7l
+fi
+
 url="https://github.com/romkatv/zsh-bin/releases/download/$tag/$distfile.tar.gz"
 
 tarname=`basename $url`
@@ -45,5 +51,5 @@ else
 fi
 
 tar -xzf $tarname
-mv zsh-5.8-linux-x86_64/* .
+mv $tarname/* .
 rm $tarname


### PR DESCRIPTION
Hi
This PR adds a simple condition in the `build.sh` to download the correct binary for zsh from the repo for the ARM architecture.

Fixes https://github.com/xxh/xxh/issues/188